### PR TITLE
Added csv table format support to imported tabulate library, did this…

### DIFF
--- a/bin/tools/awsh-json2orderedtable
+++ b/bin/tools/awsh-json2orderedtable
@@ -32,7 +32,7 @@ from awshutils.logger import AWSHLog
 from awshutils.config import get_config_from_file
 from awshutils import check_imports, clean_up
 import docopt
-from tabulate import tabulate
+from tabulate import tabulate, TableFormat, _table_formats, DataRow
 from operator import itemgetter, attrgetter
 from collections import OrderedDict
 from pprint import pprint as pp
@@ -80,6 +80,21 @@ def multikeysort(items, columns):
     sorted_items = sorted(items, cmp=comparer, key=lambda i: lowercasevalues(i))
     _log.debug('Sorted rows: {}'.format(sorted_items))
     return sorted_items
+
+
+csv = {
+    "csv": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("", ",", ""),
+        datarow=DataRow("", ",", ""),
+        padding=0,
+        with_header_hide=["lineabove"],
+    )}
+
+_table_formats.update(csv)
 
 
 def main(options):


### PR DESCRIPTION
Added csv table format support to imported tabulate library, because csv support doesn't seem to be coming (https://bitbucket.org/astanin/python-tabulate/issues/152/json-csv-tablefmt-support) and it's a handy thing to have for awsh list output.