### PR TITLE
Update requirements_os_build.alpine

### DIFF
--- a/requirements/requirements_os_build.alpine
+++ b/requirements/requirements_os_build.alpine
@@ -6,3 +6,4 @@ musl-dev
 libffi-dev
 openssl-dev
 python3-dev
+gettext


### PR DESCRIPTION
Update packages to add gettext to allow use ov envsubt on files during pipeline runs.